### PR TITLE
Add litestream:download task for git-source installs

### DIFF
--- a/lib/litestream/commands.rb
+++ b/lib/litestream/commands.rb
@@ -46,6 +46,38 @@ module Litestream
         [:cpu, :os].map { |m| Gem::Platform.local.send(m) }.join("-")
       end
 
+      def download_url
+        filename = Litestream::Upstream::NATIVE_PLATFORMS[platform]
+        raise UnsupportedPlatformException, "litestream-ruby does not support the #{platform} platform" if filename.nil?
+
+        "https://github.com/benbjohnson/litestream/releases/download/#{Litestream::Upstream::VERSION}/#{filename}"
+      end
+
+      def download(exe_path: DEFAULT_DIR)
+        require "open-uri"
+        require "zlib"
+        require "rubygems/package"
+
+        url = download_url
+        platform_dir = File.join(exe_path, platform)
+        exe_file = File.join(platform_dir, "litestream")
+
+        FileUtils.mkdir_p(platform_dir)
+
+        URI.open(url) do |remote| # standard:disable Security/Open
+          Zlib::GzipReader.wrap(remote) do |gz|
+            Gem::Package::TarReader.new(gz) do |reader|
+              reader.seek("litestream") do |file|
+                File.binwrite(exe_file, file.read)
+              end
+            end
+          end
+        end
+
+        FileUtils.chmod(0o755, exe_file)
+        exe_file
+      end
+
       def executable(exe_path: DEFAULT_DIR)
         litestream_install_dir = ENV["LITESTREAM_INSTALL_DIR"]
         if litestream_install_dir

--- a/lib/tasks/litestream_tasks.rake
+++ b/lib/tasks/litestream_tasks.rake
@@ -40,6 +40,12 @@ namespace :litestream do
     puts Litestream::Commands::Output.format(Litestream::Commands.generations(database, **options))
   end
 
+  desc "Download the Litestream binary for the current platform (required when installing from a git source)"
+  task download: :environment do
+    exe_path = Litestream::Commands.download
+    puts "Downloaded Litestream binary to #{exe_path}"
+  end
+
   desc "List all LTX files for a database or replica, for example `rake litestream:ltx -- -database=storage/production.sqlite3`"
   task ltx: :environment do
     options = parse_argv_options

--- a/test/litestream/test_download.rb
+++ b/test/litestream/test_download.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+require "fileutils"
+require "rubygems/package"
+require "zlib"
+
+class TestDownload < ActiveSupport::TestCase
+  def setup
+    @exe_dir = Litestream::Commands::DEFAULT_DIR
+    @platform = Litestream::Commands.platform
+    @platform_dir = File.join(@exe_dir, @platform)
+    @exe_path = File.join(@platform_dir, "litestream")
+    # Clean up any previously downloaded binary for test isolation
+    FileUtils.rm_rf(@platform_dir) if File.directory?(@platform_dir)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@platform_dir) if File.directory?(@platform_dir)
+  end
+
+  class TestDownloadUrl < TestDownload
+    def test_download_url_returns_correct_url_for_current_platform
+      url = Litestream::Commands.download_url
+      version = Litestream::Upstream::VERSION
+      filename = Litestream::Upstream::NATIVE_PLATFORMS[@platform]
+
+      assert_equal "https://github.com/benbjohnson/litestream/releases/download/#{version}/#{filename}", url
+    end
+
+    def test_download_url_raises_for_unsupported_platform
+      Litestream::Commands.stub :platform, "unsupported-platform" do
+        assert_raises(Litestream::Commands::UnsupportedPlatformException) do
+          Litestream::Commands.download_url
+        end
+      end
+    end
+  end
+
+  class TestDownloadExecutable < TestDownload
+    def test_download_creates_platform_directory
+      # Stub the actual HTTP download to avoid network calls in tests
+      fake_tar_gz = create_fake_tar_gz("litestream", "#!/bin/sh\necho fake")
+
+      URI.stub :open, proc { |_url, &block| block.call(StringIO.new(fake_tar_gz)) } do
+        Litestream::Commands.download
+      end
+
+      assert File.directory?(@platform_dir), "Expected #{@platform_dir} to be created"
+    end
+
+    def test_download_places_binary_in_correct_location
+      fake_tar_gz = create_fake_tar_gz("litestream", "#!/bin/sh\necho fake")
+
+      URI.stub :open, proc { |_url, &block| block.call(StringIO.new(fake_tar_gz)) } do
+        result = Litestream::Commands.download
+        assert_equal @exe_path, result
+      end
+
+      assert File.exist?(@exe_path), "Expected binary at #{@exe_path}"
+    end
+
+    def test_download_makes_binary_executable
+      fake_tar_gz = create_fake_tar_gz("litestream", "#!/bin/sh\necho fake")
+
+      URI.stub :open, proc { |_url, &block| block.call(StringIO.new(fake_tar_gz)) } do
+        Litestream::Commands.download
+      end
+
+      assert File.executable?(@exe_path), "Expected #{@exe_path} to be executable"
+    end
+
+    def test_download_is_idempotent
+      fake_tar_gz = create_fake_tar_gz("litestream", "#!/bin/sh\necho fake")
+
+      URI.stub :open, proc { |_url, &block| block.call(StringIO.new(fake_tar_gz)) } do
+        first_result = Litestream::Commands.download
+        second_result = Litestream::Commands.download
+        assert_equal first_result, second_result
+      end
+
+      assert File.exist?(@exe_path)
+    end
+
+    def test_download_raises_for_unsupported_platform
+      Litestream::Commands.stub :platform, "unsupported-platform" do
+        assert_raises(Litestream::Commands::UnsupportedPlatformException) do
+          Litestream::Commands.download
+        end
+      end
+    end
+
+    private
+
+    def create_fake_tar_gz(entry_name, content)
+      tar_io = StringIO.new
+      Gem::Package::TarWriter.new(tar_io) do |tar|
+        tar.add_file_simple(entry_name, 0o755, content.bytesize) do |io|
+          io.write(content)
+        end
+      end
+
+      gz_io = StringIO.new
+      gz = Zlib::GzipWriter.new(gz_io)
+      gz.write(tar_io.string)
+      gz.close
+      gz_io.string
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Litestream::Commands.download` method that downloads the correct platform-specific binary from GitHub releases
- Adds `Litestream::Commands.download_url` method that returns the download URL for the current platform
- Adds `litestream:download` rake task as the user-facing entry point
- Uses only stdlib (`open-uri`, `zlib`, `rubygems/package`) — no new runtime dependencies
- Extracts the binary from `.tar.gz` to `exe/<platform>/litestream` where `Commands.executable` already looks

## Why
When installing from a GitHub source (`gem "litestream", github: "bcasci/litestream-ruby", tag: "v0.15.0"`), the pre-compiled binary is not bundled. This causes `ExecutableNotFoundException` when any code invokes the Litestream binary.

## Usage
After installing from a git source, run:
```sh
bin/rails litestream:download
```

Closes #4

## Test plan
- [x] 7 new tests covering URL construction, extraction, file placement, permissions, idempotency, and unsupported platform errors
- [x] Full suite passes: 85 runs, 321 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)